### PR TITLE
2fca058173: useAppSafeArea hook

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import { StatusBar } from "expo-status-bar";
 import { themedStyleSheet } from "@theme";
 import { useFonts } from "@hooks";
 import { Button, Text } from "@components";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
 export default function App() {
   const fontsLoaded = useFonts();
@@ -12,14 +13,16 @@ export default function App() {
   }
 
   return (
-    <View style={styles.container}>
-      <Text preset="headingLarge" weight="Bold" color="primaryColor">
-        Open up App.tsx to start working on your app!
-      </Text>
+    <SafeAreaProvider>
+      <View style={styles.container}>
+        <Text preset="headingLarge" weight="Bold" color="primaryColor">
+          Open up App.tsx to start working on your app!
+        </Text>
 
-      <Button title="Button" preset="outline" />
-      <StatusBar style="auto" />
-    </View>
+        <Button title="Button" preset="outline" />
+        <StatusBar style="auto" />
+      </View>
+    </SafeAreaProvider>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "expo-font": "~13.3.2",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.6"
+    "react-native": "0.79.6",
+    "react-native-safe-area-context": "5.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/hooks/__tests__/useAppSafeArea.test.ts
+++ b/src/hooks/__tests__/useAppSafeArea.test.ts
@@ -1,0 +1,34 @@
+import { AllTheProviders, renderHook } from "test-utils";
+import { useAppSafeArea } from "../useAppSafeArea";
+import { EdgeInsets, useSafeAreaInsets } from "react-native-safe-area-context";
+
+jest.mock("react-native-safe-area-context");
+const mockedUseSafeAreaInsets = jest.mocked(useSafeAreaInsets);
+
+describe("useAppSafeArea", () => {
+  it("if the vertical insets are less than 24, it should return 24", () => {
+    mockedUseSafeAreaInsets.mockImplementationOnce(
+      () => ({ top: 10, bottom: 10 } as EdgeInsets)
+    );
+
+    const { result } = renderHook(() => useAppSafeArea(), {
+      wrapper: AllTheProviders,
+    });
+
+    expect(result.current.top).toBe(24);
+    expect(result.current.bottom).toBe(24);
+  });
+
+  it("if the vertical insets are greater than 24, it should return the insets", () => {
+    mockedUseSafeAreaInsets.mockImplementationOnce(
+      () => ({ top: 30, bottom: 30 } as EdgeInsets)
+    );
+
+    const { result } = renderHook(() => useAppSafeArea(), {
+      wrapper: AllTheProviders,
+    });
+
+    expect(result.current.top).toBe(30);
+    expect(result.current.bottom).toBe(30);
+  });
+});

--- a/src/hooks/__tests__/useFonts.test.ts
+++ b/src/hooks/__tests__/useFonts.test.ts
@@ -1,0 +1,40 @@
+import { AllTheProviders, renderHook } from "test-utils";
+import { useFonts } from "../useFonts";
+
+jest.mock("@expo-google-fonts/inter", () => ({
+  Inter_400Regular: "Inter_400Regular",
+  Inter_500Medium: "Inter_500Medium",
+  Inter_600SemiBold: "Inter_600SemiBold",
+  Inter_700Bold: "Inter_700Bold",
+  useFonts: jest.fn(),
+}));
+
+const mockedUseExpoFonts = jest.mocked(
+  require("@expo-google-fonts/inter").useFonts
+);
+
+describe("useFonts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return true if the fonts are loaded", () => {
+    mockedUseExpoFonts.mockReturnValue([true]);
+
+    const { result } = renderHook(() => useFonts(), {
+      wrapper: AllTheProviders,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("should return false if the fonts are NOT loaded", () => {
+    mockedUseExpoFonts.mockReturnValue([false]);
+
+    const { result } = renderHook(() => useFonts(), {
+      wrapper: AllTheProviders,
+    });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./useTheme";
 export * from "./useFonts";
+export * from "./useAppSafeArea";

--- a/src/hooks/useAppSafeArea.ts
+++ b/src/hooks/useAppSafeArea.ts
@@ -1,0 +1,13 @@
+import { spacing } from "@theme";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export function useAppSafeArea() {
+  const insets = useSafeAreaInsets();
+
+  return {
+    top: Math.max(insets.top, spacing.s24),
+    bottom: Math.max(insets.bottom, spacing.s24),
+    left: insets.left,
+    right: insets.right,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6559,6 +6559,11 @@ react-native-is-edge-to-edge@^1.1.6:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
+react-native-safe-area-context@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz#04b51940408c114f75628a12a93569d30c525454"
+  integrity sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==
+
 react-native@0.79.6:
   version "0.79.6"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.79.6.tgz#ee95428f67da2f62ede473eaa6e8a2f4ee40e272"


### PR DESCRIPTION
## Description
This PR implements a new hook called ```useAppSafeArea``` where its main purpose is to return the safe area values from ```useSafeAreaInsets```, but it always keep a minimum value to vertical insets to follow. So if the device vertical (top/bottom) insets are lower than the minimum required, it returns the minimum requirement.

## Checklist

- [x] Tests added for new functionality
- [x] All tests pass 
- [x] Code follows project conventions
- [x] No breaking changes
- [x] Documentation is up to date (if applicable)